### PR TITLE
Added Lineage Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/src/api/__tests__/release.test.ts
+++ b/src/api/__tests__/release.test.ts
@@ -4,7 +4,8 @@ import {
     releaseGetMany,
     releaseUpdate,
     releasePublish,
-    releaseSearch
+    releaseSearch,
+    releaseLineage
 } from '../release';
 import {v4 as uuid} from 'uuid';
 import Boom from '@hapi/boom';
@@ -146,6 +147,21 @@ describe('search', () => {
         expect(second.items[0]).toEqual(archived);
     });
 });
+
+describe('lineage', () => {
+    it('will return the lineage for a given release in descending order', async () => {
+        const createdOne = await releaseCreate({name: 'createdOne'});
+        const createdTwo = await releaseCreate({name: 'createdTwo', parentId: createdOne.id});
+        const createdThree = await releaseCreate({name: 'createdThree', parentId: createdTwo.id});
+        const lineage = await releaseLineage({id: createdThree.id});
+
+        expect(lineage).toHaveLength(3);
+        // Descending Order
+        expect(lineage[0].name).toEqual('createdThree');
+        expect(lineage[1].name).toEqual('createdTwo')
+        expect(lineage[2].name).toEqual('createdOne')
+    })
+})
 
 describe('selections', () => {
     it('will create selections for each provided build', async () => {

--- a/src/api/release.ts
+++ b/src/api/release.ts
@@ -1,11 +1,13 @@
-import {createHandler} from '../util/handler';
+import { createHandler } from '../util/handler';
 import Release from '../models/release/Release';
-import {releaseCreateSchema} from '../models/release/schemas';
-import {releaseGetSchema} from '../models/release/schemas';
-import {releaseUpdateSchema} from '../models/release/schemas';
-import {releasePublishSchema} from '../models/release/schemas';
-import {releaseGetManySchema} from '../models/release/schemas';
-import {releaseSearchSchema} from '../models/release/schemas';
+import { releaseCreateSchema } from '../models/release/schemas';
+import { releaseGetSchema } from '../models/release/schemas';
+import { releaseUpdateSchema } from '../models/release/schemas';
+import { releasePublishSchema } from '../models/release/schemas';
+import { releaseGetManySchema } from '../models/release/schemas';
+import { releaseSearchSchema } from '../models/release/schemas';
+import { releaseLineageSchema } from '../models/release/schemas';
+// Just following convention, this could be import {releaseCreateSchema, releaseGetSchema ..., releaseLineageSchema} from '../models/release/schemas';
 
 export const releaseCreate = createHandler(
     () => releaseCreateSchema,
@@ -53,3 +55,8 @@ export const releaseSearch = createHandler(
         return await Release.search(input);
     }
 );
+
+export const releaseLineage = createHandler(() => releaseLineageSchema, async (input) => {
+    const releases = await Release.lineage(input)
+    return Promise.all(releases.map((ii) => ii.asPrimitive(false)));
+})

--- a/src/models/build/get.ts
+++ b/src/models/build/get.ts
@@ -5,8 +5,8 @@ import {BuildGetSchema, BuildGetManySchema} from './schemas';
 
 export async function getById(input: BuildGetSchema) {
     const {db} = await config();
-    const {id} = input;
-    const data = (await db.oneOrNone(`select * from builds where id = $[id]`, {
+    const {id, orderByAsc = true} = input;
+    const data = (await db.oneOrNone(`select * from builds where id = $[id] ORDER BY end_date ${orderByAsc ? 'ASC' : 'DESC'}`, {
         id
     })) as BuildData | null;
     return data ? new Build(data) : null;

--- a/src/models/build/schemas.ts
+++ b/src/models/build/schemas.ts
@@ -3,7 +3,8 @@ import {pagination} from '../../schemas/paginationSchema';
 
 export const buildGetSchema = z.object({
     id: z.number().int(),
-    includeArchived: z.boolean().optional()
+    includeArchived: z.boolean().optional(),
+    orderByAsc: z.boolean().optional()
 });
 
 export const buildGetManySchema = z

--- a/src/models/release/lineage.ts
+++ b/src/models/release/lineage.ts
@@ -1,0 +1,20 @@
+import Release from './Release';
+import { getByIdOrThrow } from './get';
+import { ReleaseGetSchema, } from './schemas';
+
+export default async function lineage(input: ReleaseGetSchema): Promise<Release[]> {
+    const { id } = input;
+
+    const requestedRelease: Release = await getByIdOrThrow({ id, includeArchived: true });
+
+    let releaseDataList: Release[] = [requestedRelease];
+    let parentId = requestedRelease?.parentId
+
+    while (parentId) {
+        const release: Release = await getByIdOrThrow({ id: parentId, includeArchived: true });
+        releaseDataList.push(release);
+        parentId = release.parentId
+    }
+
+    return releaseDataList
+}

--- a/src/models/release/schemas.ts
+++ b/src/models/release/schemas.ts
@@ -53,6 +53,10 @@ export const releasePublishSchema = z.object({
     id: z.number().int()
 });
 
+export const releaseLineageSchema = z.object({
+    id: z.number().int(),
+});
+
 export type ReleaseCreateSchema = z.infer<typeof releaseCreateSchema>;
 export type ReleaseGetManySchema = z.infer<typeof releaseGetManySchema>;
 export type ReleaseGetSchema = z.infer<typeof releaseGetSchema>;


### PR DESCRIPTION
Added a new lineage endpoint which returns an array of releases based on parent Ids.

New endpoint takes in one parameter; the release ID to obtain the lineage from. I was unsure about how the data should be formatted, but I was thinking the `selections()` function was a hint so each of the releases gets the build details. The get builds DB query was manipulated a bit to pass in a parameter for searching by date ascending or descending (DB engine uses ascending by default so this wouldn't have met the criteria).

A decision could be made for whether each release is a roundtrip to the database (as implemented) or whether all the releases should be returned in the DB query and the response can be determined by manipulating the JSON.


**Future enhancements**
As the release numbers grow, I would be putting in a maximum depth of parent releases as this is going to grow infinitely.


Testing Evidence:

![image](https://github.com/ed-whittle/bigdatr-code-challenge/assets/81550691/5232c134-e09d-45ef-8647-978f64ffd011)


Sample Response:
```
[
    {
        "id": 6,
        "parentId": 5,
        "name": "Sixth release",
        "createdAt": "2022-11-30T13:00:00.000Z",
        "updatedAt": "2022-11-30T13:00:00.000Z",
        "status": "LIVE",
        "selections": [
            {
                "id": 8,
                "build": {
                    "id": 8,
                    "name": "Automated build 4",
                    "requiresReview": false,
                    "startDate": "2021-06-01T00:00:00.000Z",
                    "endDate": "2021-12-01T00:00:00.000Z"
                },
                "startDate": "2021-06-01T00:00:00.000Z",
                "endDate": "2021-12-01T00:00:00.000Z"
            }
        ]
    },
    {
        "id": 5,
        "parentId": 4,
        "name": "Fifth release",
        "createdAt": "2022-02-28T13:00:00.000Z",
        "updatedAt": "2022-02-28T13:00:00.000Z",
        "status": "PREVIOUS",
        "selections": [
            {
                "id": 7,
                "build": {
                    "id": 7,
                    "name": "Manual build 3",
                    "requiresReview": false,
                    "startDate": "2021-05-01T00:00:00.000Z",
                    "endDate": "2021-06-01T00:00:00.000Z"
                },
                "startDate": "2021-05-01T00:00:00.000Z",
                "endDate": "2021-06-01T00:00:00.000Z"
            }
        ]
    },
    {
        "id": 4,
        "parentId": 2,
        "name": "Fourth release",
        "createdAt": "2022-01-09T13:00:00.000Z",
        "updatedAt": "2022-01-09T13:00:00.000Z",
        "status": "PREVIOUS",
        "selections": [
            {
                "id": 5,
                "build": {
                    "id": 5,
                    "name": "Automated build 3",
                    "requiresReview": false,
                    "startDate": "2021-01-01T00:00:00.000Z",
                    "endDate": "2021-06-01T00:00:00.000Z"
                },
                "startDate": "2021-01-01T00:00:00.000Z",
                "endDate": "2021-06-01T00:00:00.000Z"
            },
            {
                "id": 6,
                "build": {
                    "id": 6,
                    "name": "Manual build 2",
                    "requiresReview": false,
                    "startDate": "2021-01-01T00:00:00.000Z",
                    "endDate": "2021-02-01T00:00:00.000Z"
                },
                "startDate": "2021-01-01T00:00:00.000Z",
                "endDate": "2021-02-01T00:00:00.000Z"
            }
        ]
    },
    {
        "id": 2,
        "parentId": 1,
        "name": "Second release",
        "createdAt": "2022-01-02T13:00:00.000Z",
        "updatedAt": "2022-01-02T13:00:00.000Z",
        "status": "PREVIOUS",
        "selections": [
            {
                "id": 2,
                "build": {
                    "id": 2,
                    "name": "Automated build 1",
                    "requiresReview": false,
                    "startDate": "2020-05-01T00:00:00.000Z",
                    "endDate": "2020-10-01T00:00:00.000Z"
                },
                "startDate": "2020-05-01T00:00:00.000Z",
                "endDate": "2020-10-01T00:00:00.000Z"
            }
        ]
    },
    {
        "id": 1,
        "parentId": null,
        "name": "First release",
        "createdAt": "2021-12-31T13:00:00.000Z",
        "updatedAt": "2021-12-31T13:00:00.000Z",
        "status": "PREVIOUS",
        "selections": [
            {
                "id": 1,
                "build": {
                    "id": 1,
                    "name": "Initial build",
                    "requiresReview": false,
                    "startDate": "2020-01-01T00:00:00.000Z",
                    "endDate": "2020-06-01T00:00:00.000Z"
                },
                "startDate": "2020-01-01T00:00:00.000Z",
                "endDate": "2020-05-01T00:00:00.000Z"
            }
        ]
    }
]
```

